### PR TITLE
feat:페이지네이션 및 쿼리스트링 api개발

### DIFF
--- a/src/components/category/index.tsx
+++ b/src/components/category/index.tsx
@@ -1,19 +1,19 @@
 import React from 'react'
+import {URLSearchParamsInit, useSearchParams} from 'react-router-dom'
+import {useQuery} from '@tanstack/react-query'
 import styled from '@emotion/styled'
-import {Box, Typography} from '@mui/material'
 import FlexBox from '@layouts/flex-box'
-import CustomIcons from '@assets/icons/custom-Icons'
 import instance from '@api/instance'
 
-import {useQuery} from '@tanstack/react-query'
-
-import {URLSearchParamsInit, useSearchParams} from 'react-router-dom'
+import CustomIcons from '@assets/icons/custom-Icons'
+import {Box, Skeleton, Typography} from '@mui/material'
 
 interface CategoryProps {
   currentCategory: string
   setCurrentCategory: React.Dispatch<React.SetStateAction<string>>
   searchParams?: URLSearchParamsInit
   setSearchParams?: React.Dispatch<React.SetStateAction<URLSearchParamsInit>>
+  setCategoryId?: React.Dispatch<React.SetStateAction<number>>
 }
 
 type CategoryNameType = {
@@ -23,6 +23,8 @@ type CategoryNameType = {
   thumbnail?: string
   img?: string
 }
+
+const isLoadingData = Array.from({length: 11}, (_, index) => index + 1)
 
 /** 카테고리 목록 조회 */
 const fetchGetCategories = async () => {
@@ -37,7 +39,11 @@ const fetchGetCategories = async () => {
   }
 }
 
-const Category = ({currentCategory, setCurrentCategory}: CategoryProps) => {
+const Category = ({
+  currentCategory,
+  setCurrentCategory,
+  setCategoryId,
+}: CategoryProps) => {
   const [searchParams, setSearchParams] = useSearchParams()
 
   const query = searchParams.get('category')
@@ -51,14 +57,15 @@ const Category = ({currentCategory, setCurrentCategory}: CategoryProps) => {
     queryFn: fetchGetCategories,
   })
 
-  const setQueryParams = (categoryName: string) => {
+  const setQueryParams = (category: any) => {
     if (categories) {
-      console.log(categoryName)
-      setCurrentCategory(categoryName)
+      setCurrentCategory(category?.name)
 
       setSearchParams({
-        category: categoryName,
+        categoryId: category?.id,
       })
+
+      setCategoryId && setCategoryId(category?.id)
     }
   }
 
@@ -84,8 +91,6 @@ const Category = ({currentCategory, setCurrentCategory}: CategoryProps) => {
     }
   }
 
-  if (isLoading) return 'Loading...'
-
   if (error) return 'An error has occurred: ' + error
 
   return (
@@ -94,84 +99,100 @@ const Category = ({currentCategory, setCurrentCategory}: CategoryProps) => {
         <CustomIcons.BeforeIcon />
       </Box>
 
-      {categories?.length !== 0 &&
-        categories?.map(category => (
-          <FlexBox
-            direction="column"
-            alignItems="center"
-            gap=""
-            style={{
-              cursor: 'pointer',
-            }}
-            onClick={() => setQueryParams(category.name)}
-            key={category.id}
-          >
-            {category.thumbnail ? (
-              <CategoryImg
-                clicked={
-                  (query && query === category.name) ||
-                  (!query && currentCategory === category.name)
-                    ? 'true'
-                    : ''
-                }
-                src={category.img}
-                alt="category 이미지"
-              />
-            ) : (
-              <>
-                {(query && query === category.name) ||
-                (!query && currentCategory === category.name) ? (
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="78"
-                    height="78"
-                    viewBox="0 0 78 78"
-                    fill="none"
-                  >
-                    <circle
-                      cx="39"
-                      cy="39"
-                      r="38.625"
-                      fill="white"
-                      stroke="#FE7156"
-                      strokeWidth="0.75"
-                    />
-                    <circle cx="39" cy="39" r="36" fill="#F1F1F5" />
-                  </svg>
+      {isLoading ? (
+        <>
+          {isLoadingData.map((_, index) => (
+            <Skeleton
+              sx={{bgcolor: 'grey.200'}}
+              variant="circular"
+              width={78}
+              height={78}
+              key={index}
+            />
+          ))}
+        </>
+      ) : (
+        <>
+          {categories?.length !== 0 &&
+            categories?.map(category => (
+              <FlexBox
+                direction="column"
+                alignItems="center"
+                gap=""
+                style={{
+                  cursor: 'pointer',
+                }}
+                onClick={() => setQueryParams(category)}
+                key={category.id}
+              >
+                {category.thumbnail ? (
+                  <CategoryImg
+                    clicked={
+                      (query && query === category.name) ||
+                      (!query && currentCategory === category.name)
+                        ? 'true'
+                        : ''
+                    }
+                    src={category.img}
+                    alt="category 이미지"
+                  />
                 ) : (
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="78"
-                    height="78"
-                    viewBox="0 0 78 78"
-                    fill="none"
-                  >
-                    <circle
-                      cx="39"
-                      cy="39"
-                      r="38.625"
-                      fill="white"
-                      stroke="#EDEDED"
-                      strokeWidth="0.75"
-                    />
-                    <circle cx="39" cy="39" r="36" fill="#F1F1F5" />
-                  </svg>
+                  <>
+                    {(query && query === category.name) ||
+                    (!query && currentCategory === category.name) ? (
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="78"
+                        height="78"
+                        viewBox="0 0 78 78"
+                        fill="none"
+                      >
+                        <circle
+                          cx="39"
+                          cy="39"
+                          r="38.625"
+                          fill="white"
+                          stroke="#FE7156"
+                          strokeWidth="0.75"
+                        />
+                        <circle cx="39" cy="39" r="36" fill="#F1F1F5" />
+                      </svg>
+                    ) : (
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="78"
+                        height="78"
+                        viewBox="0 0 78 78"
+                        fill="none"
+                      >
+                        <circle
+                          cx="39"
+                          cy="39"
+                          r="38.625"
+                          fill="white"
+                          stroke="#EDEDED"
+                          strokeWidth="0.75"
+                        />
+                        <circle cx="39" cy="39" r="36" fill="#F1F1F5" />
+                      </svg>
+                    )}
+                  </>
                 )}
-              </>
-            )}
 
-            <CategoryName
-              clicked={
-                (query && query === category.name) ||
-                (!query && currentCategory === category.name)
-                  ? 'true'
-                  : ''
-              }
-            >
-              {category.name}
-            </CategoryName>
-          </FlexBox>
-        ))}
+                <CategoryName
+                  clicked={
+                    (query && query === category.name) ||
+                    (!query && currentCategory === category.name)
+                      ? 'true'
+                      : ''
+                  }
+                >
+                  {category.name}
+                </CategoryName>
+              </FlexBox>
+            ))}
+        </>
+      )}
 
       <Box sx={{cursor: 'pointer'}} onClick={handleRightArrowClick}>
         <CustomIcons.AfterIcon />
@@ -193,8 +214,8 @@ const CategoryImg = styled.img<{clicked: string}>(({clicked}) => ({
   border: clicked ? '1px solid #FE7156' : '1px solid #F1F1F5',
   cursor: 'pointer',
   transition: 'all 0.1s ease-in-out',
-  width: '72px',
-  height: '72px',
+  width: '78px',
+  height: '78px',
 
   '&:hover': {
     border: '1px solid #FE7156',

--- a/src/pages/perfume-detail/index.tsx
+++ b/src/pages/perfume-detail/index.tsx
@@ -5,7 +5,7 @@ import FlexBox from '@layouts/flex-box'
 import Notes from './notes'
 import Information from './information'
 import Review from '@pages/perfume-detail/review'
-import PerfumesItem from '@pages/perfumes/perfumes-item'
+// import PerfumesItem from '@pages/perfumes/perfumes-item'
 
 import {Box, Button, Pagination, Typography} from '@mui/material'
 
@@ -20,7 +20,7 @@ const PerfumeDetail = () => {
 
   const [page, setPage] = useState(1) // 처음 페이지는 1
   const [reviewData, setReviewData] = useState<string[]>([])
-  const [perfumes, setPerfumes] = useState<string[]>([])
+  // const [perfumes, setPerfumes] = useState<string[]>([])
 
   console.log(reviewData)
 
@@ -41,7 +41,7 @@ const PerfumeDetail = () => {
 
   // 임시
   useEffect(() => {
-    setPerfumes(dummydata.slice(0, 4) as any)
+    // setPerfumes(dummydata.slice(0, 4) as any)
   }, [])
 
   return (
@@ -153,8 +153,8 @@ const PerfumeDetail = () => {
       {/* 비슷한 향수 리스트 */}
       <ProductListTitle>비슷한 향수</ProductListTitle>
       <ProductList>
-        {perfumes.length > 0 &&
-          perfumes?.map(item => <PerfumesItem item={item} key={item} />)}
+        {/* {perfumes.length > 0 &&
+          perfumes?.map(item => <PerfumesItem item={item} key={item} />)} */}
       </ProductList>
     </Container>
   )

--- a/src/pages/perfumes/perfumes-item.tsx
+++ b/src/pages/perfumes/perfumes-item.tsx
@@ -1,31 +1,48 @@
 import styled from '@emotion/styled'
 import {Typography} from '@mui/material'
-
 import {Link} from 'react-router-dom'
 
-// 타입 추후에 설정할 예정입니다.
-const PerfumesItem = ({item}: any) => {
-  console.log(item)
+interface PerfumesItemProps {
+  item: ItemType
+}
 
+export type ItemType = {
+  brandName: string
+  duration: string
+  id: number
+  name: string
+  strength: string
+  thumbnailUrl?: string
+}
+
+const PerfumesItem = ({item}: PerfumesItemProps) => {
+  const {brandName, duration, name, strength, thumbnailUrl} = item
+  console.log(item)
   return (
     <Wrapper>
       <Link to="/perfume/:id">
         <ProductWrapper>
-          <img src="/images/Rectangle7217(5).png" alt="img" />
-          <BrandTitle>구딸파리</BrandTitle>
-          <BrandSubTitle>로즈폼퐁 오 드 퍼퓸</BrandSubTitle>
+          {thumbnailUrl ? (
+            <img src={thumbnailUrl} alt="img" />
+          ) : (
+            <img src="/images/Rectangle7217(5).png" alt="img" />
+          )}
+
+          <BrandTitle>{brandName}</BrandTitle>
+          <BrandSubTitle>{name}</BrandSubTitle>
         </ProductWrapper>
 
         <Information>
           <Text>
-            <Type>강도</Type>적당한 향
+            <Type>강도</Type>
+            {strength}
           </Text>
 
           <div className="vertical-line" />
 
           <Text>
             <Type>지속력</Type>
-            3시간~6시간
+            {duration}
           </Text>
         </Information>
       </Link>


### PR DESCRIPTION
# 제품 리스트 페이지 개발 내용

- 페이지네이션 구현,
- url 쿼리를 통한 사용자가 새로고침을해도 방금 전에 눌렀던 탭의 데이터를 유지할 수 있게 구현했습니다.

ex) http://localhost:5173/perfumes?categoryId=1  , 카테고리 탭만 눌렀을 경우
ex) http://localhost:5173/perfumes?categoryId=1&page=1, 카테고리탭을 누르고, 페이지를 이동시켰을 경우