### PR TITLE
refector: 타입 스크립트 네이밍 규칙 정립으로 변경 

### DIFF
--- a/src/hooks/use-auth-redirect.tsx
+++ b/src/hooks/use-auth-redirect.tsx
@@ -1,23 +1,15 @@
-// import {useMutation} from '@tanstack/react-query'
-import axios, {AxiosResponse} from 'axios'
+import axios from 'axios'
 import {useCallback} from 'react'
 import {useNavigate} from 'react-router-dom'
-import {fetchUserProfile} from 'src/store/server/auth/mutations'
+import {fetchUserProfile} from 'src/store/server/auth/queries'
 import useMutation from 'src/store/server/use-mutation'
-
-interface Data {
-  userId: number
-  username: string
-  thumbnail: string
-}
 
 const useAuthRedirect = () => {
   const navigate = useNavigate()
   const redirectAuth = async () => {
     try {
       const res = await fetchUserProfile()
-      const data = await res.data
-      return data
+      return res
     } catch (error) {
       // 에러코드별로 에러 처리
       if (axios.isAxiosError(error) && error.response) {
@@ -48,7 +40,7 @@ const useAuthRedirect = () => {
     }
   }
 
-  const {mutate} = useMutation<AxiosResponse<Data>>({
+  const {mutate} = useMutation({
     mutationKey: ['userProfile'],
     mutationFn: redirectAuth,
     options: {

--- a/src/pages/sign-in/sign-in-form.tsx
+++ b/src/pages/sign-in/sign-in-form.tsx
@@ -12,7 +12,7 @@ import useMutation from 'src/store/server/use-mutation'
 import {useNavigate} from 'react-router-dom'
 import SignInOptions from './sign-in-options'
 import SignInButtonGroup from './sign-in-button-group'
-import {fetchLogin} from 'src/store/server/auth/mutations'
+import {postLogin} from 'src/store/server/auth/mutations'
 
 const SignInForm = () => {
   const [value, setValue] = useState(0)
@@ -27,7 +27,7 @@ const SignInForm = () => {
   const nav = useNavigate()
 
   const {mutate} = useMutation({
-    mutationFn: fetchLogin,
+    mutationFn: postLogin,
     mutationKey: ['sign-in'],
     options: {
       onError: error => alert(error),

--- a/src/pages/sign-up/hooks/use-sign-up-id-check.tsx
+++ b/src/pages/sign-up/hooks/use-sign-up-id-check.tsx
@@ -1,0 +1,16 @@
+import {postSignUpIdDuplicationCheck} from 'src/store/server/auth/mutations'
+import useMutation from 'src/store/server/use-mutation'
+
+const useSignUpIdCheck = () => {
+  const {mutate} = useMutation({
+    mutationFn: postSignUpIdDuplicationCheck,
+    mutationKey: ['test'],
+    options: {
+      onError: () => console.log('d'),
+    },
+  })
+
+  return {mutate}
+}
+
+export default useSignUpIdCheck

--- a/src/pages/sign-up/sign-up-agreement/form-agreement-modal.tsx
+++ b/src/pages/sign-up/sign-up-agreement/form-agreement-modal.tsx
@@ -1,4 +1,5 @@
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos'
+import {Box, DialogContent, DialogContentText, Typography} from '@mui/material'
 import Dialog from '@mui/material/Dialog'
 import DialogTitle from '@mui/material/DialogTitle'
 import {useState} from 'react'
@@ -25,10 +26,89 @@ const FormAgreementModal: React.FC<Props> = ({index}) => {
           color: '#707070',
         }}
       />
-      <Dialog open={open} onClose={() => setOpen(false)}>
-        <DialogTitle>Set backup account</DialogTitle>
+      <Dialog
+        open={open}
+        className="안녕"
+        onClose={() => setOpen(false)}
+        sx={{
+          '.MuiDialog-container > .MuiPaper-root': {
+            width: '100%',
+            height: '100%',
+            maxWidth: '100%',
+            margin: 0,
+            paddingTop: '250px',
+          },
+        }}
+      >
+        <Box sx={{width: '700px', margin: 'auto'}}>
+          <DialogTitle>
+            <Typography variant="h1">서비스 이용 약관</Typography>
+          </DialogTitle>
+          <DialogContent>
+            {modals.map(modal => (
+              <>
+                <Typography variant="body4" sx={{fontWeight: 600}}>
+                  {modal.title}
+                </Typography>
+                <DialogContentText variant="body4">
+                  {modal.description}
+                </DialogContentText>
+              </>
+            ))}
+          </DialogContent>
+        </Box>
       </Dialog>
     </>
   )
 }
 export default FormAgreementModal
+
+const modals = [
+  {
+    title: '제 1조',
+    description: `이 약관은 화장품 리뷰 서비스(이하 "서비스")의 이용조건 및 절차, 이용자와 서비스의 권리·의무 및 책임사항을 규정함을 목적으로 합니다.`,
+  },
+  {
+    title: '제 2조',
+    description: `회원가입은 온라인으로 이루어지며, 서비스 이용을 희망하는 이용자는 서비스에서 정한 가입 양식에 개인 정보를 기입하여 회원가입을 신청합니다.
+    모든 이용자는 회원가입 시 실명과 실제 정보를 사용해야 하며, 가입 시 제공한 정보는 정확해야 합니다.`,
+  },
+  {
+    title: '제 3조',
+    description: `회원가입은 온라인으로 이루어지며, 서비스 이용을 희망하는 이용자는 서비스에서 정한 가입 양식에 개인 정보를 기입하여 회원가입을 신청합니다.
+
+    모든 이용자는 회원가입 시 실명과 실제 정보를 사용해야 하며, 가입 시 제공한 정보는 정확해야 합니다.`,
+  },
+  {
+    title: '제 4조',
+    description: `서비스는 이용자의 정보를 보호하기 위해 보안 시스템을 갖추고 있습니다. 이용자의 개인정보는 개인정보보호정책에 따라 보호됩니다.`,
+  },
+  {
+    title: '제 5조',
+    description: `서비스는 필요한 경우 약관의 내용을 변경할 수 있으며, 변경된 약관은 서비스 홈페이지에 공지하며, 공지 후 7일 이후부터 효력이 발생합니다.`,
+  },
+  {
+    title: '제 6조',
+    description: `서비스는 이용자가 본 약관의 내용에 위반하는 행위를 하는 경우, 사전 통보 없이 서비스 이용을 제한하거나 회원 자격을 상실시킬 수 있습니다.`,
+  },
+  {
+    title: '제 7조',
+    description: `서비스는 다음 각 호의 경우로 서비스를 제공할 수 없는 경우 이로 인해 이용자 또는 제3자가 입은 손해에 대해서는 책임을 지지 않습니다.
+
+    -천재지변 또는 이에 준하는 불가항력의 상태가 있는 경우
+    -서비스 제공을 위하여 서비스와 계약을 체결한 제3자의 고의·과실이 있는 경우
+    -이용자의 고의·과실로 인하여 서비스 이용에 장애가 있는 경우`,
+  },
+  {
+    title: '제 8조',
+    description: `본 약관의 해석 및 서비스 이용과 관련하여 이용자와 서비스 사이에 발생한 분쟁은 대한민국의 법을 적용하여 해결합니다.`,
+  },
+  {
+    title: '제 9조',
+    description: `본 약관에 명시되지 않은 사항은 관계 법령 및 서비스가 정한 개별 약관 등의 규정에 따릅니다.`,
+  },
+  {
+    title: '제 10조',
+    description: `이 약관은 서비스가 온라인 홈페이지에 게시함으로써 효력이 발생합니다. 이용자는 정기적으로 서비스를 방문하여 약관의 변경사항을 확인하는 책임이 있습니다.`,
+  },
+]

--- a/src/pages/sign-up/sign-up-form.tsx
+++ b/src/pages/sign-up/sign-up-form.tsx
@@ -6,7 +6,7 @@ import FormAgreement from './sign-up-agreement'
 import {formData} from './data.constant'
 import {useNavigate} from 'react-router-dom'
 import useMutation from 'src/store/server/use-mutation'
-import {fetchSignUp} from 'src/store/server/auth/mutations'
+import {postSignUp} from 'src/store/server/auth/mutations'
 import SignUpHeader from './sign-up-header'
 import SignUpFooter from './sign-up-footer'
 import SignupInputsIndividual from './sign-up-inputs-individual'
@@ -23,7 +23,7 @@ const SignUpForm = () => {
   const nav = useNavigate()
 
   const {mutate} = useMutation({
-    mutationFn: fetchSignUp,
+    mutationFn: postSignUp,
     mutationKey: ['sign-up'],
   })
 
@@ -32,6 +32,8 @@ const SignUpForm = () => {
       username: data.username,
       password: data.password,
       email: data.email,
+      marketingConsent: false,
+      promotionConsent: false,
     }
     mutate(newData, {
       onSuccess: () => nav('/'),

--- a/src/store/server/auth/mutations.interface.ts
+++ b/src/store/server/auth/mutations.interface.ts
@@ -1,4 +1,0 @@
-export interface FetchLoginProps {
-  username: string
-  password: string
-}

--- a/src/store/server/auth/mutations.ts
+++ b/src/store/server/auth/mutations.ts
@@ -1,17 +1,25 @@
 import instance from '@api/instance'
-import {FetchLoginProps} from './mutations.interface'
+import {IfLogin, IfSignUp} from 'types/auth.interface'
 
-export const fetchLogin = async (data: FetchLoginProps) => {
+export const postLogin = async (data: IfLogin) => {
   return await instance.post('/login', {...data})
 }
 
-export const fetchUserProfile = async () => {
-  return await instance.get('/me')
+export const postSignUp: (
+  signUpdata: IfSignUp,
+) => Promise<IfLogin> = async signUpdata => {
+  const API_URL = '/signup/email'
+  const res = await instance.post(API_URL, {
+    ...signUpdata,
+  })
+  const data = await res.data
+  return data
 }
 
-export const fetchSignUp = async data => {
-  const API_URL = '/signup/email'
-  return await instance.post(API_URL, {
-    ...data,
+export const postSignUpIdDuplicationCheck = async (userId: string) => {
+  const res = await instance.post('/signup/check-username', {
+    userId,
   })
+  const data = await res.data
+  return data
 }

--- a/src/store/server/auth/queries.ts
+++ b/src/store/server/auth/queries.ts
@@ -1,6 +1,12 @@
 import instance from '@api/instance'
+import { IfLoginUserProfile } from 'types/auth.interface'
 
 export const fetchRefreshToken = async () => {
   const url = '/reissue'
   return await instance.get(url)
+}
+export const fetchUserProfile: () => Promise<IfLoginUserProfile> = async () => {
+  const res = await instance.get('/me')
+  const data = await res.data
+  return data
 }

--- a/src/types/auth.interface.ts
+++ b/src/types/auth.interface.ts
@@ -1,0 +1,23 @@
+// 로그인
+export interface IfLogin {
+  username: string
+  password: string
+}
+
+//로그인 중인 유저 프로필 조회
+
+export interface IfLoginUserProfile extends IfLogin {
+  thumbnail: string
+}
+
+//회원가입 요청
+export interface IfSignUp extends IfLogin {
+  email: string
+  marketingConsent: boolean
+  promotionConsent: boolean
+}
+
+//회원가입 아이디 중복체크 요청
+export interface IfSignUpIdDuplicationCheck {
+  userId: string
+}


### PR DESCRIPTION
- 타입 스크립트 네이밍 iF로 시작하도록 변경
- types 폴더 생성 auth.interface 작성 
- API 네이밍 get은 fetch로 시작하도록 변경