### PR TITLE
fix: 아이디 중복 체크 요청 시 폼 유효성 통과못하면 API 전송 차단하도록 수정

### DIFF
--- a/src/components/base/mui-button.tsx
+++ b/src/components/base/mui-button.tsx
@@ -8,6 +8,7 @@ export interface ButtonProps {
   handleClick?: (event: React.MouseEvent<HTMLButtonElement> | any) => void
   height?: string
   formType?: 'button' | 'submit'
+  disabled?: boolean
 }
 
 const MuiButton: React.FC<ButtonProps> = ({
@@ -18,6 +19,7 @@ const MuiButton: React.FC<ButtonProps> = ({
   handleClick,
   height = '48px',
   formType = 'button',
+  disabled = false,
 }) => {
   const theme = useTheme()
 
@@ -45,6 +47,7 @@ const MuiButton: React.FC<ButtonProps> = ({
     <Button
       variant="contained"
       type={formType}
+      disabled={disabled}
       sx={{
         '&.MuiButtonBase-root': {
           width: `${width ? width : '100%'}`,

--- a/src/pages/sign-up/data.constant.ts
+++ b/src/pages/sign-up/data.constant.ts
@@ -63,7 +63,7 @@ export const formData = {
   email: {
     label: '본인 확인 이메일',
     name: 'email',
-    placeholder: '8~16자 / 문자, 숫자, 특수 문자 모두 혼용',
+    placeholder: '@필수',
     register: {
       required: {
         value: true,

--- a/src/pages/sign-up/hooks/use-post-check-duplicate .tsx
+++ b/src/pages/sign-up/hooks/use-post-check-duplicate .tsx
@@ -10,8 +10,8 @@ interface IfProps {
   failedMessage: string
 }
 
-const usePostIdCheck = ({successMessage, failedMessage}: IfProps) => {
-  const {setError} = useFormContext()
+const usePostCheckDuplicate = ({successMessage, failedMessage}: IfProps) => {
+  const {setError,trigger} = useFormContext()
   const {mutate: mutateCheckUserId} = useMutation({
     mutationFn: postSignUpIdDuplicationCheck,
     mutationKey: ['userIdCheck'],
@@ -26,7 +26,7 @@ const usePostIdCheck = ({successMessage, failedMessage}: IfProps) => {
     },
   })
 
-  const {mutate: checkEmailMutate, data: emailRes} = useMutation({
+  const {mutate: checkEmailMutate} = useMutation({
     mutationFn: postSignUpEmailDuplicationCheck,
     mutationKey: ['email'],
     options: {
@@ -40,7 +40,20 @@ const usePostIdCheck = ({successMessage, failedMessage}: IfProps) => {
     },
   })
 
-  return {mutateCheckUserId, checkEmailMutate, emailRes}
+  //아이디 중복체크 
+  const handleIdDuplicateCheck = async (usernameFildValue:string) => {
+    if ((await trigger('username')) === true) {
+      mutateCheckUserId(usernameFildValue)
+    }
+  }
+  // 이메일 중복체크 
+  const handleEmailDuplicateCheck = async (emailFildValue:string) => {
+    if ((await trigger('email')) === true) {
+      checkEmailMutate(emailFildValue)
+    }
+  }
+
+  return {mutateCheckUserId, checkEmailMutate, handleIdDuplicateCheck,handleEmailDuplicateCheck }
 }
 
-export default usePostIdCheck
+export default usePostCheckDuplicate

--- a/src/pages/sign-up/hooks/use-validate-form.tsx
+++ b/src/pages/sign-up/hooks/use-validate-form.tsx
@@ -1,9 +1,11 @@
 import {useController, useFormContext} from 'react-hook-form'
 import {formData} from '../data.constant'
 
-const useValidationForm = () => {
-  const {control, watch} = useFormContext()
-
+const useValidateForm = () => {
+  const {control, watch, getFieldState} = useFormContext()
+  const test = getFieldState('username')
+  console.log(test, 'Test')
+  
   const username = useController({
     name: 'username', // defaultsvalues 저장한 객체 키
     control,
@@ -92,4 +94,4 @@ const useValidationForm = () => {
   }
 }
 
-export default useValidationForm
+export default useValidateForm

--- a/src/pages/sign-up/sign-up-agreement/index.tsx
+++ b/src/pages/sign-up/sign-up-agreement/index.tsx
@@ -1,16 +1,13 @@
 import {Box, Button, Checkbox, Typography, styled} from '@mui/material'
-import {
-  useFormContext,
-} from 'react-hook-form'
+import {useFormContext} from 'react-hook-form'
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
-import useValidationForm from '../hooks/use-validation-form'
+import useValidateForm from '../hooks/use-validate-form'
 import CheckBoxItem from './checkbox-item'
 
 const SignUpAgreement = () => {
   const {watch, setValue} = useFormContext()
-  const {allCheck, age, promotionConsent, marketingConsent} =
-    useValidationForm()
+  const {allCheck, age, promotionConsent, marketingConsent} = useValidateForm()
 
   const handleUseFormAllCheck = () => {
     const newValue = watch('allCheck')

--- a/src/pages/sign-up/sign-up-email-check/index.tsx
+++ b/src/pages/sign-up/sign-up-email-check/index.tsx
@@ -4,16 +4,16 @@ import MuiButton from '@components/base/mui-button'
 interface Props {
   title: string
   value: string
-  handleClick: (id: string) => void
+  handleEmailDuplicateCheck: (id: string) => void
 }
-const SignUpEmailCheck = ({title, value, handleClick}: Props) => {
+const SignUpEmailCheck = ({title, value, handleEmailDuplicateCheck}: Props) => {
   return (
     <Box sx={{position: 'absolute', right: '-100px', top: '35px'}}>
       <MuiButton
         formType="button"
         type="dark"
         title={title}
-        handleClick={() => handleClick(value)}
+        handleClick={() => handleEmailDuplicateCheck(value)}
       />
     </Box>
   )

--- a/src/pages/sign-up/sign-up-id-check/index.tsx
+++ b/src/pages/sign-up/sign-up-id-check/index.tsx
@@ -1,19 +1,18 @@
 import {Box} from '@mui/material'
 import MuiButton from '@components/base/mui-button'
 
+
 interface Props {
   title: string
   value: string
-  handleClick: (id: string) => void
+  handleIdDuplicateCheck: (id: string) => void
 }
-const SignUpIdCheck = ({title, value, handleClick}: Props) => {
+const SignUpIdCheck = ({title, value, handleIdDuplicateCheck}:Props) => {
+
+ 
   return (
     <Box sx={{position: 'absolute', right: '-100px', top: '35px'}}>
-      <MuiButton
-        type="dark"
-        title={title}
-        handleClick={() => handleClick(value)}
-      />
+      <MuiButton type="dark" title={title} handleClick={() => handleIdDuplicateCheck(value)} />
     </Box>
   )
 }

--- a/src/pages/sign-up/sign-up-inputs/index.tsx
+++ b/src/pages/sign-up/sign-up-inputs/index.tsx
@@ -1,14 +1,14 @@
 import {List, ListItem, styled} from '@mui/material'
 import SignUpValidation from './sign-up-validation'
-import useValidationForm from '../hooks/use-validation-form'
 import {formData} from '../data.constant'
 import SignUpIdCheck from '../sign-up-id-check'
-import usePostIdCheck from '../hooks/use-post-id-check'
 import SignUpEmailCheck from '../sign-up-email-check'
+import usePostCheckDuplicate from '../hooks/use-post-check-duplicate '
+import useValidateForm from '../hooks/use-validate-form'
 
 const SignupInputs = () => {
-  const {username, password, confirmPassword, email} = useValidationForm()
-  const {mutateCheckUserId, checkEmailMutate} = usePostIdCheck({
+  const {username, password, confirmPassword, email} = useValidateForm()
+  const {handleIdDuplicateCheck, handleEmailDuplicateCheck} = usePostCheckDuplicate({
     successMessage: '사용 가능합니다',
     failedMessage: '아이디 중복입니다.',
   })
@@ -25,7 +25,7 @@ const SignupInputs = () => {
             <SignUpIdCheck
               title="중복확인"
               value={username.field.value}
-              handleClick={mutateCheckUserId}
+              handleIdDuplicateCheck={handleIdDuplicateCheck}
             />
           }
         />
@@ -56,7 +56,7 @@ const SignupInputs = () => {
             <SignUpEmailCheck
               title="인증"
               value={email.field.value}
-              handleClick={checkEmailMutate}
+              handleEmailDuplicateCheck={handleEmailDuplicateCheck}
             />
           }
         />


### PR DESCRIPTION
- 아이디 중복체크시 폼 유효성 통과해야 API 전송하도록 수정
- 아이디 중복체크 실패 시 alert => 하단 helperText 에러메시지로 변경
- 이메일 중복체크시 폼 유효성 통과해야 API 전송하도록 수정
- 이메일 중복체크 실패 시 alert => 하단 helperText 에러메시지로 변경