### PR TITLE
fix:메인페이지 노트 사이즈제한 및 제품리스트페이지 크기고정

### DIFF
--- a/src/pages/home/note-products.tsx
+++ b/src/pages/home/note-products.tsx
@@ -33,7 +33,7 @@ const NoteProducts = ({categoryId}: {categoryId: number}) => {
     data: perfumes,
   } = useQuery<PerfumesType>(
     ['perfumes-by-note', categoryId],
-    () => fetchPerfumeList(categoryId, 0),
+    () => fetchPerfumeList(categoryId, 0, 6),
     {
       keepPreviousData: false,
     },

--- a/src/pages/perfumes/index.tsx
+++ b/src/pages/perfumes/index.tsx
@@ -185,7 +185,7 @@ const Perfumes = () => {
         />
 
         {/* 제품 리스트 */}
-        <Box sx={{height: '799px'}}>
+        <Box sx={{minHeight: '799px'}}>
           {perfumesLoading ? (
             <>
               <PerfumeSkeleton skeletons={skeletons} />
@@ -193,13 +193,6 @@ const Perfumes = () => {
           ) : (
             <>
               <PerfumeList perfumeListData={perfumeListData.content} />
-
-              {perfumeListData.content.length === 0 && (
-                <NotPerfumeText>
-                  향수 없이는 세상이 흑백인데, 우리 제품이 없어서 모두 향기로운
-                  색채가 사라진 것 같아요! 🌈🚫
-                </NotPerfumeText>
-              )}
             </>
           )}
           <Footer>
@@ -314,15 +307,6 @@ const SLink = styled(Link)({
   '&:hover img': {
     transform: 'scale(1.098)',
   },
-})
-
-const NotPerfumeText = styled(Typography)({
-  color: ' #ABABAB',
-  fontAmily: 'Pretendard',
-  fontSize: ' 19.5px',
-  fontWeight: 500,
-  lineHeight: 'normal',
-  textAlign: 'center',
 })
 
 export default Perfumes

--- a/src/store/server/categories/queries.ts
+++ b/src/store/server/categories/queries.ts
@@ -18,10 +18,12 @@ export const fetchCategories = async (): Promise<IfCategory[]> => {
 export const fetchPerfumeList = async (
   queryCategoryId: number,
   page: number,
+  size?: number,
 ) => {
   try {
+    console.log(queryCategoryId, page, size)
     const res = await instance.get(`/perfumes/category/${queryCategoryId}`, {
-      params: {page: page, size: '10'},
+      params: {page: page, size: size ? size : '10'},
     })
 
     const data = res.data


### PR DESCRIPTION
- 메인페이지에서 노트 사이즈 6개 제한
- 제품리스트페이지 크기고정 작업